### PR TITLE
Add cond, quote and assign

### DIFF
--- a/parens/eval.py
+++ b/parens/eval.py
@@ -29,6 +29,18 @@ def dot_extraction(x, env):
                           "exactly two arguments.")
 
 
+def wants_env(f):
+    from inspect import signature
+    try:
+        sig = signature(f)
+    except ValueError:
+        return False
+    for param in sig.parameters.values():
+        if (param.kind == param.KEYWORD_ONLY and
+            param.name == 'env'):
+            return True
+    return False
+
 def eval(x, env=global_env):
     """
     Evaluate an expression x in an env
@@ -120,7 +132,10 @@ def eval(x, env=global_env):
         # OK, input is of the form (f arg1 arg2 ... argn)
         args = [eval(arg, env) for arg in x[1:]]
         try:
-            return proc(*args)
+            if wants_env(proc):
+                return proc(*args, env=env)
+            else:
+                return proc(*args)
         except TypeError as e:
             if callable(proc):
                 # Callable, but wrong number of args or something

--- a/parens/lex.py
+++ b/parens/lex.py
@@ -28,9 +28,11 @@ def lex(characters):
             if len(current_token) > 0:
                 tokens.append(current_token)
                 current_token = ""
-            pos += 1
-            assert characters[pos] == '('
-            tokens.append("'(")
+            if characters[pos + 1] == '(':
+                pos += 1
+                tokens.append("'(")
+            else:
+                current_token += "'"
 
 
         # Open paren token - commit current_token and commit a (

--- a/parens/lex.py
+++ b/parens/lex.py
@@ -22,6 +22,17 @@ def lex(characters):
                 tokens.append(current_token)
                 current_token = ""
 
+        # Quote token - commit current_token and commit a '(
+        elif characters[pos] == "'":
+            # Quote
+            if len(current_token) > 0:
+                tokens.append(current_token)
+                current_token = ""
+            pos += 1
+            assert characters[pos] == '('
+            tokens.append("'(")
+
+
         # Open paren token - commit current_token and commit a (
         elif characters[pos] == "(":
             # Open paren

--- a/parens/parse.py
+++ b/parens/parse.py
@@ -24,6 +24,9 @@ def preparse(tokens):
         elif token == '\'(':
             count_open += 1
             current_list.append('\'(')
+        elif token.startswith("'"):
+            current_list.append('"{}"'.format(token[1:]))
+            continue
         elif token == ')':
             if count_open == 0:
                 # Too many closing parens

--- a/parens/parse.py
+++ b/parens/parse.py
@@ -21,7 +21,9 @@ def preparse(tokens):
         if token == '(':
             count_open += 1
             current_list.append('(')
-
+        elif token == '\'(':
+            count_open += 1
+            current_list.append('\'(')
         elif token == ')':
             if count_open == 0:
                 # Too many closing parens
@@ -55,8 +57,10 @@ def parse_single(tokens):
     token = tokens.pop(0)
     # We need to have a paren to start a list, otherwise we'll just eval one
     # TODO
-    if token == '(':
+    if token in ('\'(', '('):
         L = []
+        if token == '\'(':
+            L.append('quote')
         try:
             while tokens[0] != ')':
                 # Until we get to the end of this paren enclosure, recurse

--- a/parens/plistd.py
+++ b/parens/plistd.py
@@ -5,3 +5,12 @@
 def makelist(*args):
     " Create a list from arguments. "
     return list(args)
+
+
+def quote(*args):
+    return ['"{}"'.format(a) if isinstance(a, str) else a for a in args]
+
+
+def cond(test, then, else_=False, *, env):
+    from .eval import eval
+    return eval(then if test else else_, env)

--- a/parens/plistd.py
+++ b/parens/plistd.py
@@ -14,3 +14,7 @@ def quote(*args):
 def cond(test, then, else_=False, *, env):
     from .eval import eval
     return eval(then if test else else_, env)
+
+def assign(name, val, *, env):
+    env[name] = val
+    return val


### PR DESCRIPTION
Hey,

I've added some functions implemented as Python procs rather than special cases in `eval`.

It also has some changes to `eval` and the parser to accommodate this, so you can do:

```
 (cond (= a b)
   '(print "a and b are already equal!")
   '(assign 'a b))
```
